### PR TITLE
feat(CreateMarketModal): create near account & deploy market contract

### DIFF
--- a/app/public/locales/en/latest-trends.json
+++ b/app/public/locales/en/latest-trends.json
@@ -8,7 +8,7 @@
   "latestTrends.createMarketModal.input.resolutionInfo": "Info to resolute the market",
   "latestTrends.createMarketModal.input.resolutionInfo.placeholder": "Info",
   "latestTrends.createMarketModal.input.marketEndDatetime": "When does this market end?",
-  "latestTrends.createMarketModal.input.marketEndDatetime.placeholder": "dd.mm.year | UTC time",
+  "latestTrends.createMarketModal.input.marketStartDatetime": "When does this market start?",
   "latestTrends.createMarketModal.input.collateralToken": "Collateral token",
   "latestTrends.createMarketModal.input.collateralToken.placeholder": "dd.mm.year | UTC time",
   "latestTrends.createMarketModal.input.marketOptions": "Market options",
@@ -16,5 +16,7 @@
   "latestTrends.createMarketModal.form.submit": "Submit",
   "latestTrends.createMarketModal.input.marketEndDate": "Date",
   "latestTrends.createMarketModal.input.marketEndTime": "Time",
-  "latestTrends.createMarketModal.input.marketEndTimezone": "Timezone"
+  "latestTrends.createMarketModal.input.marketEndTimezone": "Timezone",
+  "latestTrends.createMarketModal.input.marketStartDate": "Date",
+  "latestTrends.createMarketModal.input.marketStartTime": "Time"
 }

--- a/app/public/locales/es/latest-trends.json
+++ b/app/public/locales/es/latest-trends.json
@@ -8,7 +8,7 @@
   "latestTrends.createMarketModal.input.resolutionInfo": "Info to resolute the market",
   "latestTrends.createMarketModal.input.resolutionInfo.placeholder": "Info",
   "latestTrends.createMarketModal.input.marketEndDatetime": "When does this market end?",
-  "latestTrends.createMarketModal.input.marketEndDatetime.placeholder": "dd.mm.year | UTC time",
+  "latestTrends.createMarketModal.input.marketStartDatetime": "When does this market start?",
   "latestTrends.createMarketModal.input.collateralToken": "Collateral token",
   "latestTrends.createMarketModal.input.collateralToken.placeholder": "dd.mm.year | UTC time",
   "latestTrends.createMarketModal.input.marketOptions": "Market options",
@@ -16,5 +16,7 @@
   "latestTrends.createMarketModal.form.submit": "Submit",
   "latestTrends.createMarketModal.input.marketEndDate": "Date",
   "latestTrends.createMarketModal.input.marketEndTime": "Time",
-  "latestTrends.createMarketModal.input.marketEndTimezone": "Timezone"
+  "latestTrends.createMarketModal.input.marketEndTimezone": "Timezone",
+  "latestTrends.createMarketModal.input.marketStartDate": "Date",
+  "latestTrends.createMarketModal.input.marketStartTime": "Time"
 }

--- a/app/src/app/dashboard/latest-trends/create-market-modal/CreateMarketModal.tsx
+++ b/app/src/app/dashboard/latest-trends/create-market-modal/CreateMarketModal.tsx
@@ -16,22 +16,74 @@ import pulse from "providers/pulse";
 import { Styles } from "ui/icon/Icon.module.scss";
 import timezones from "providers/date/timezones.json";
 import { CategoryPills } from "ui/category-pills/CategoryPills";
+import date from "providers/date";
+import near from "providers/near";
+import { DEFAULT_FEE_RATIO, DEFAULT_NETWORK_ENV, DEFAULT_RESOLUTION_WINDOW_DAY_SPAN } from "providers/near/getConfig";
+import { useToastContext } from "hooks/useToastContext/useToastContext";
+import useNearMarketContract from "providers/near/contracts/market/useNearMarketContract";
 
-import { CreateMarketModalProps } from "./CreateMarketModal.types";
 import styles from "./CreateMarketModal.module.scss";
+import { CreateMarketModalForm, CreateMarketModalProps } from "./CreateMarketModal.types";
 
 const generateTimezoneOffsetString = (offset: number, suffix: string) => `${offset}_${suffix}`;
+const getTimezoneOffsetString = (input: string) => input.match(/.*?(?=_|$)/i)![0];
+const getCollateralTokenAccountId = (symbol: string) =>
+  pulse.getConfig().COLLATERAL_TOKENS.filter((token) => token.symbol === symbol)[0].accountId;
 
 export const CreateMarketModal: React.FC<CreateMarketModalProps> = ({ className, onClose }) => {
-  const [collateralToken, setCollateralToken] = useState(pulse.getConfig().COLLATERAL_TOKENS[0].symbol);
+  const [collateralTokenSymbol, setCollateralTokenSymbol] = useState(pulse.getConfig().COLLATERAL_TOKENS[0].symbol);
   const [marketEndTimezoneOffset, setMarketEndTimezoneOffset] = useState(
     generateTimezoneOffsetString(timezones[0].offset, timezones[0].value),
   );
 
   const { t } = useTranslation(["latest-trends", "common"]);
+  const toast = useToastContext();
 
-  const onSubmit = (values: Record<string, unknown>) => {
-    console.log({ ...values, collateralToken, marketEndTimezoneOffset });
+  const { contract: marketContract } = useNearMarketContract();
+
+  const onSubmit = (values: CreateMarketModalForm) => {
+    try {
+      const startsAt = date.parseFromFormat(
+        `${values.marketStartDate} ${values.marketStartTime} ${getTimezoneOffsetString(marketEndTimezoneOffset)}`,
+        "YYYY-MM-DD HH:mm Z",
+        false,
+      );
+
+      const endsAt = date.parseFromFormat(
+        `${values.marketEndDate} ${values.marketEndTime} ${getTimezoneOffsetString(marketEndTimezoneOffset)}`,
+        "YYYY-MM-DD HH:mm Z",
+        false,
+      );
+
+      const resolutionWindow = endsAt.add(DEFAULT_RESOLUTION_WINDOW_DAY_SPAN, "days");
+
+      const daoAccountId = near.getConfig(DEFAULT_NETWORK_ENV).marketDaoAccountId;
+      const collateralTokenAccountId = getCollateralTokenAccountId(collateralTokenSymbol);
+
+      const args = {
+        market: {
+          description: values.marketDescription,
+          info: "market info",
+          category: values.marketCategory,
+          options: [values.defaultMarketOption, ...values.marketOptions],
+          starts_at: date.toNanoseconds(startsAt.valueOf()),
+          ends_at: date.toNanoseconds(endsAt.valueOf()),
+        },
+        dao_account_id: daoAccountId,
+        collateral_token_account_id: collateralTokenAccountId,
+        fee_ratio: DEFAULT_FEE_RATIO,
+        resolution_window: date.toNanoseconds(resolutionWindow.valueOf()),
+      };
+
+      marketContract.deploy(args);
+    } catch {
+      toast.trigger({
+        variant: "error",
+        withTimeout: true,
+        title: "Oops, our bad.",
+        children: <Typography.Text>While creating the market. Try again?</Typography.Text>,
+      });
+    }
   };
 
   return (
@@ -98,9 +150,9 @@ export const CreateMarketModal: React.FC<CreateMarketModalProps> = ({ className,
                         id="collateralToken"
                         inputProps={{
                           onChange: (value) => {
-                            setCollateralToken(value as string);
+                            setCollateralTokenSymbol(value as string);
                           },
-                          value: collateralToken,
+                          value: collateralTokenSymbol,
                         }}
                       >
                         {pulse.getConfig().COLLATERAL_TOKENS.map((token) => (
@@ -166,6 +218,24 @@ export const CreateMarketModal: React.FC<CreateMarketModalProps> = ({ className,
                   </div>
                   <div className={styles["create-market-modal__spacer"]} />
                   <Typography.Headline3>
+                    {t("latestTrends.createMarketModal.input.marketStartDatetime")}
+                  </Typography.Headline3>
+                  <Grid.Row>
+                    <Grid.Col lg={4} xs={12}>
+                      <Form.Label htmlFor="marketStartDate">
+                        {t("latestTrends.createMarketModal.input.marketStartDate")}
+                      </Form.Label>
+                      <Form.TextInput id="marketStartDate" type="date" />
+                    </Grid.Col>
+                    <Grid.Col lg={3} xs={12}>
+                      <Form.Label htmlFor="marketStartTime">
+                        {t("latestTrends.createMarketModal.input.marketStartTime")}
+                      </Form.Label>
+                      <Form.TextInput id="marketStartTime" type="time" />
+                    </Grid.Col>
+                  </Grid.Row>
+                  <div className={styles["create-market-modal__spacer"]} />
+                  <Typography.Headline3>
                     {t("latestTrends.createMarketModal.input.marketEndDatetime")}
                   </Typography.Headline3>
                   <Grid.Row>
@@ -181,7 +251,9 @@ export const CreateMarketModal: React.FC<CreateMarketModalProps> = ({ className,
                       </Form.Label>
                       <Form.TextInput id="marketEndTime" type="time" />
                     </Grid.Col>
-                    <Grid.Col lg={5} xs={12}>
+                  </Grid.Row>
+                  <Grid.Row>
+                    <Grid.Col lg={12} xs={12}>
                       <Form.Label htmlFor="marketEndTimezone">
                         {t("latestTrends.createMarketModal.input.marketEndTimezone")}
                       </Form.Label>

--- a/app/src/app/dashboard/latest-trends/create-market-modal/CreateMarketModal.types.ts
+++ b/app/src/app/dashboard/latest-trends/create-market-modal/CreateMarketModal.types.ts
@@ -5,3 +5,16 @@ export type CreateMarketModalProps = {
   className?: string;
   onClose: () => void;
 };
+
+export type CreateMarketModalForm = {
+  collateralToken: string;
+  defaultMarketOption: string;
+  marketCategory: string;
+  marketDescription: string;
+  marketStartDate: string;
+  marketStartTime: string;
+  marketEndDate: string;
+  marketEndTime: string;
+  marketEndTimezoneOffset: string;
+  marketOptions: Array<string>;
+};

--- a/app/src/providers/date/index.ts
+++ b/app/src/providers/date/index.ts
@@ -1,3 +1,5 @@
+import { MomentFormatSpecification, MomentInput } from "moment";
+
 import timeFromNow from "./timeFromNow";
 import client from "./client";
 import getDefaultDateFormat, {
@@ -7,7 +9,11 @@ import getDefaultDateFormat, {
   toUtcOffsetNanoseconds,
 } from "./getDefaultDateFormat";
 
+const parseFromFormat = (inp?: MomentInput, format?: MomentFormatSpecification, strict?: boolean) =>
+  client(inp, format, strict);
+
 export default {
+  parseFromFormat,
   timeFromNow,
   getDefaultDateFormat,
   toNanoseconds,

--- a/app/src/providers/near/contracts/market/constants.ts
+++ b/app/src/providers/near/contracts/market/constants.ts
@@ -1,0 +1,20 @@
+export const VIEW_METHODS = [
+  "get_market_data",
+  "get_fee_ratio",
+  "get_price_ratio",
+  "get_balance_boost_ratio",
+  "get_outcome_token",
+  "get_block_timestamp",
+  "get_collateral_token_metadata",
+  "dao_account_id",
+  "published_at",
+  "resolved_at",
+  "is_published",
+  "is_resolved",
+  "is_open",
+  "is_over",
+  "is_resolution_window_expired",
+  "balance_of",
+];
+
+export const CHANGE_METHODS = ["publish", "buy", "sell", "new"];

--- a/app/src/providers/near/contracts/market/index.ts
+++ b/app/src/providers/near/contracts/market/index.ts
@@ -1,0 +1,59 @@
+import { Contract } from "near-api-js";
+import * as nearAPI from "near-api-js";
+
+import nearUtils from "providers/near";
+import date from "providers/date";
+import { DEFAULT_NETWORK_ENV } from "../../getConfig";
+
+import { DeployMarketContractArgs, MarketContractMethods, MarketContractValues } from "./market.types";
+import { VIEW_METHODS } from "./constants";
+
+export class MarketContract {
+  values: MarketContractValues | undefined;
+
+  contract: Contract & MarketContractMethods;
+
+  contractAddress: string;
+
+  constructor(contract: Contract & MarketContractMethods) {
+    this.contract = contract;
+    this.contractAddress = contract.contractId;
+  }
+
+  static getDefaultContractValues = (): MarketContractValues => ({
+    totalFunds: "0",
+    fundingAmountLimit: nearUtils.formatAccountBalance("0"),
+    unpaidFundingAmount: nearUtils.formatAccountBalance("0"),
+    depositsOf: "0",
+    depositsOfPercentage: 0,
+    currentCoinPrice: 0,
+    priceEquivalence: 0,
+    totalFundedPercentage: 0,
+    expirationDate: date.toNanoseconds(date.now().toDate().getTime()),
+    daoFactoryAccountId: "",
+    ftFactoryAccountId: "",
+    daoName: "",
+    metadataURL: "",
+    isDepositAllowed: false,
+    isWithdrawalAllowed: false,
+    deposits: [],
+  });
+
+  static async deploy(args: DeployMarketContractArgs) {
+    // @TODO impl
+    return args;
+  }
+
+  static async getFromConnection(contractAddress: string) {
+    const near = await nearAPI.connect({
+      keyStore: new nearAPI.keyStores.InMemoryKeyStore(),
+      headers: {},
+      ...nearUtils.getConfig(DEFAULT_NETWORK_ENV),
+    });
+
+    const account = await near.account(nearUtils.getConfig(DEFAULT_NETWORK_ENV).guestWalletId);
+    const contractMethods = { viewMethods: VIEW_METHODS, changeMethods: [] };
+
+    return nearUtils.initContract<MarketContractMethods>(account, contractAddress, contractMethods);
+  }
+}

--- a/app/src/providers/near/contracts/market/market.types.ts
+++ b/app/src/providers/near/contracts/market/market.types.ts
@@ -1,0 +1,53 @@
+export type MarketData = {
+  description: string;
+  info: string;
+  category: string;
+  options: Array<string>;
+  starts_at: number;
+  ends_at: number;
+};
+
+export type DeployMarketContractArgs = {
+  market: MarketData;
+  dao_account_id: string;
+  collateral_token_account_id: string;
+  fee_ratio: number;
+  resolution_window: number;
+};
+
+export type MarketContractValues = {
+  totalFunds: string;
+  fundingAmountLimit: string;
+  unpaidFundingAmount: string;
+  totalFundedPercentage: number;
+  currentCoinPrice: number;
+  priceEquivalence: number;
+  expirationDate: number;
+  daoFactoryAccountId: string;
+  ftFactoryAccountId: string;
+  daoName: string;
+  metadataURL: string;
+  isDepositAllowed: boolean;
+  isWithdrawalAllowed: boolean;
+  deposits: string[][];
+  depositsOf: string;
+  depositsOfPercentage: number;
+};
+
+export type MarketContractMethods = {
+  get_total_funds: () => Promise<number>;
+  get_funding_amount_limit: () => Promise<number>;
+  get_unpaid_funding_amount: () => Promise<number>;
+  get_deposits: () => Promise<string[][]>;
+  get_expiration_date: () => Promise<number>;
+  get_dao_factory_account_id: () => Promise<string>;
+  get_ft_factory_account_id: () => Promise<string>;
+  get_dao_name: () => Promise<string>;
+  get_metadata_url: () => Promise<string>;
+  is_deposit_allowed: () => Promise<boolean>;
+  is_withdrawal_allowed: () => Promise<boolean>;
+  deposits_of: ({ payee }: { payee: string }) => Promise<number>;
+  deposit: (args: Record<string, string>, gas?: number, amount?: string | null) => Promise<void>;
+  withdraw: () => Promise<void>;
+  delegate_funds: ({ dao_name }: { dao_name: string }, gas: string | number) => Promise<boolean>;
+};

--- a/app/src/providers/near/contracts/market/useNearMarketContract.ts
+++ b/app/src/providers/near/contracts/market/useNearMarketContract.ts
@@ -1,0 +1,5 @@
+import { MarketContract } from ".";
+
+export default () => ({
+  contract: MarketContract,
+});

--- a/app/src/providers/near/getConfig.ts
+++ b/app/src/providers/near/getConfig.ts
@@ -1,45 +1,18 @@
 export const DEFAULT_NETWORK_ENV = "testnet";
+export const DEFAULT_FEE_RATIO = 0.02;
+export const DEFAULT_RESOLUTION_WINDOW_DAY_SPAN = 3; // days
 
 const CONTRACT_NAME = process.env.CONTRACT_NAME || "testnet";
 
 const TESTNET_GUEST_WALLET_ID = "nearholdings.testnet";
 const MAINNET_GUEST_WALLET_ID = "communitycapital.near";
 
-const TESTNET_DAO_CONTRACT_NAME = "sputnikv2.testnet";
-const MAINNET_DAO_CONTRACT_NAME = "sputnik-dao.near";
-
-const TESTNET_ESCROWFACTORY_CONTRACT_NAME = "escrowfactory.nearholdings.testnet";
-const MAINNET_ESCROWFACTORY_CONTRACT_NAME = "escrowfactory.communitycapital.near";
-
-const TESTNET_DAOFACTORY_CONTRACT_NAME = "daofactory2.nearholdings.testnet";
-const MAINNET_DAOFACTORY_CONTRACT_NAME = "daofactory.communitycapital.near";
-
-const TESTNET_FTFACTORY_CONTRACT_NAME = "ftfactory2.nearholdings.testnet";
-const MAINNET_FTFACTORY_CONTRACT_NAME = "ftfactory.communitycapital.near";
-
-const TESTNET_SKFACTORY_CONTRACT_NAME = "stakingfactory.nearholdings.testnet";
-const MAINNET_SKFACTORY_CONTRACT_NAME = "stakingfactory.communitycapital.near";
-
-const TESTNET_ASTRODAO_URL_ORIGIN = "https://dev.app.astrodao.com";
-const MAINNET_ASTRODAO_URL_ORIGIN = "https://app.astrodao.com";
-
-const TESTNET_FEATURED_ACTIVE_HOLDINGS = [
-  "ce_eay7eydcxk8nwp8rvo6zpo.escrowfactory.nearholdings.testnet",
-  "ce_1t0tchrruu9l8zmkknpi1t.escrowfactory.nearholdings.testnet",
-  "ce_fjfpt2dryzyfyfjsf597lq.escrowfactory.nearholdings.testnet",
-];
-const MAINNET_FEATURED_ACTIVE_HOLDINGS = ["ce_k95zme9rxsppqvjfw2gyvj.escrowfactory12.nearholdings.testnet"];
+const TESTNET_DAO_ACCOUNT_ID = "pulse-dao.sputnikv2.testnet";
+const MAINNET_DAO_ACCOUNT_ID = "pulse-dao.sputnikv2.near";
 
 const TESTNET_CONFIG = {
+  marketDaoAccountId: TESTNET_DAO_ACCOUNT_ID,
   guestWalletId: TESTNET_GUEST_WALLET_ID,
-  contractName: CONTRACT_NAME,
-  daoContractName: TESTNET_DAO_CONTRACT_NAME,
-  escrowFactoryContractName: TESTNET_ESCROWFACTORY_CONTRACT_NAME,
-  daoFactoryContractName: TESTNET_DAOFACTORY_CONTRACT_NAME,
-  ftFactoryContractName: TESTNET_FTFACTORY_CONTRACT_NAME,
-  skFactoryContractName: TESTNET_SKFACTORY_CONTRACT_NAME,
-  featuredActiveHoldings: TESTNET_FEATURED_ACTIVE_HOLDINGS,
-  astroDaoURLOrigin: TESTNET_ASTRODAO_URL_ORIGIN,
 };
 
 export default (network: string | undefined) => {
@@ -48,18 +21,12 @@ export default (network: string | undefined) => {
       return {
         networkId: "mainnet",
         nodeUrl: "https://rpc.mainnet.near.org",
-        guestWalletId: MAINNET_GUEST_WALLET_ID,
-        contractName: CONTRACT_NAME,
-        daoContractName: MAINNET_DAO_CONTRACT_NAME,
-        escrowFactoryContractName: MAINNET_ESCROWFACTORY_CONTRACT_NAME,
-        daoFactoryContractName: MAINNET_DAOFACTORY_CONTRACT_NAME,
-        ftFactoryContractName: MAINNET_FTFACTORY_CONTRACT_NAME,
-        skFactoryContractName: MAINNET_SKFACTORY_CONTRACT_NAME,
-        featuredActiveHoldings: MAINNET_FEATURED_ACTIVE_HOLDINGS,
-        astroDaoURLOrigin: MAINNET_ASTRODAO_URL_ORIGIN,
         walletUrl: "https://wallet.near.org",
         helperUrl: "https://helper.mainnet.near.org",
         explorerUrl: "https://explorer.near.org",
+        marketDaoAccountId: MAINNET_DAO_ACCOUNT_ID,
+        guestWalletId: MAINNET_GUEST_WALLET_ID,
+        contractName: CONTRACT_NAME,
       };
     case "test":
     case "testnet":

--- a/app/src/providers/pulse/getConfig.ts
+++ b/app/src/providers/pulse/getConfig.ts
@@ -1,9 +1,10 @@
 export default () => ({
   COLLATERAL_TOKENS: [
-    { icon: "icon-near", symbol: "PULSE" },
-    { icon: "icon-near", symbol: "REF" },
-    { icon: "icon-near", symbol: "CHEDDAR" },
-    { icon: "icon-near", symbol: "NEAR" },
+    { icon: "icon-near", symbol: "USDT", accountId: "usdt.fakes.testnet" },
+    { icon: "icon-near", symbol: "PULSE", accountId: "pulse.fakes.testnet" },
+    { icon: "icon-near", symbol: "REF", accountId: "ref.fakes.testnet" },
+    { icon: "icon-near", symbol: "CHEDDAR", accountId: "cheddar.fakes.testnet" },
+    { icon: "icon-near", symbol: "NEAR", accountId: "near.fakes.testnet" },
   ],
   MARKET_CATEGORIES: [
     // @TODO icons should be PNG images paths


### PR DESCRIPTION
WIP
This PR implements the Market contract deployment from the contract .wasm file.

Submitting the modal form should trigger a createAccount transaction and a deployment transaction. After deployment, the UI should: 

- redirect the user to the market details page
- create a record of the new contract account_id (in another PR), for indexing (until the market factory works as expected)