### PR TITLE
refactor([marketId]): getServerSideProps

### DIFF
--- a/app/src/pages/market/[marketId].tsx
+++ b/app/src/pages/market/[marketId].tsx
@@ -1,10 +1,9 @@
-import { GetStaticPropsContext, NextPage } from "next";
+import { GetServerSidePropsContext, NextPage } from "next";
 import { i18n } from "next-i18next";
 import { serverSideTranslations } from "next-i18next/serverSideTranslations";
 
 import { DashboardLayout } from "layouts/dashboard-layout/DashboardLayout";
 import { MarketContainer } from "app/dashboard/market/market/MarketContainer";
-import { MarketFactoryContract } from "providers/near/contracts/market-factory";
 import { MarketContainerProps } from "app/dashboard/market/market/Market.types";
 
 const Market: NextPage<MarketContainerProps> = ({ marketId }) => (
@@ -13,18 +12,7 @@ const Market: NextPage<MarketContainerProps> = ({ marketId }) => (
   </DashboardLayout>
 );
 
-export async function getStaticPaths() {
-  const marketFactory = await MarketFactoryContract.loadFromGuestConnection();
-  const marketsList = await marketFactory.getMarketsList();
-  const paths = marketsList?.map((marketId) => ({ params: { marketId } }));
-
-  return {
-    paths,
-    fallback: false,
-  };
-}
-
-export async function getStaticProps({ locale, params }: GetStaticPropsContext) {
+export async function getServerSideProps({ locale, params }: GetServerSidePropsContext) {
   const marketId = params?.marketId;
   await i18n?.reloadResources();
 

--- a/app/src/providers/near/getConfig.ts
+++ b/app/src/providers/near/getConfig.ts
@@ -2,8 +2,6 @@ export const DEFAULT_NETWORK_ENV = "testnet";
 export const DEFAULT_FEE_RATIO = 0.02;
 export const DEFAULT_RESOLUTION_WINDOW_DAY_SPAN = 3; // days
 
-const CONTRACT_NAME = process.env.CONTRACT_NAME || "testnet";
-
 const TESTNET_GUEST_WALLET_ID = "nearholdings.testnet";
 const MAINNET_GUEST_WALLET_ID = "communitycapital.near";
 
@@ -35,7 +33,6 @@ export default (network: string | undefined) => {
         marketDaoAccountId: MAINNET_DAO_ACCOUNT_ID,
         marketDaoUrl: MAINNET_DAO_URL,
         guestWalletId: MAINNET_GUEST_WALLET_ID,
-        contractName: CONTRACT_NAME,
       };
     case "test":
     case "testnet":


### PR DESCRIPTION
Refactor from `getStaticPaths` to `getServerSideProps` since we are loading dynamic markets.